### PR TITLE
feat: implement 11Labs webhook endpoint with authentication

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,33 @@
+# Application Configuration
+STACK_NAME=dev
+FASTAPI_DEBUG=false
+LOGGING_LEVEL=INFO
+
+# AI Model Configuration
+MODEL=anthropic/claude-sonnet-4-5-20250929
+
+# Direct API Keys (for local development)
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+
+# Langfuse Configuration (optional)
+LANGFUSE_PUBLIC_KEY=your-langfuse-public-key-here
+LANGFUSE_SECRET_KEY=your-langfuse-secret-key-here
+LANGFUSE_HOST=https://us.cloud.langfuse.com
+
+# Supabase Configuration
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-supabase-anon-key
+
+# 11Labs Webhook Authentication
+ELEVENLABS_WEBHOOK_AUTH=your-secure-webhook-auth-token-here
+
+# AWS Configuration (for Lambda deployment)
+# SQS_QUEUE_URL=https://sqs.region.amazonaws.com/account-id/queue-name
+
+# AWS Secrets Manager Names (for Lambda deployment)
+# ANTHROPIC_API_KEY_SECRET_NAME=gen-ai-on-aws/dev/anthropic_api_key
+# LANGFUSE_PUBLIC_KEY_SECRET_NAME=gen-ai-on-aws/dev/langfuse_public_key
+# LANGFUSE_SECRET_KEY_SECRET_NAME=gen-ai-on-aws/dev/langfuse_secret_key
+# SUPABASE_URL_SECRET_NAME=gen-ai-on-aws/dev/supabase_url
+# SUPABASE_KEY_SECRET_NAME=gen-ai-on-aws/dev/supabase_key
+# ELEVENLABS_WEBHOOK_AUTH_SECRET_NAME=gen-ai-on-aws/dev/elevenlabs_webhook_auth

--- a/api/docs/elevenlabs-webhook.md
+++ b/api/docs/elevenlabs-webhook.md
@@ -1,0 +1,170 @@
+# 11Labs Webhook Integration
+
+## Overview
+
+This webhook endpoint handles conversation initiation requests from 11Labs conversational AI agents. It fetches dynamic configuration data from Supabase and returns variables that can be used to personalize the conversation.
+
+## Endpoint
+
+```
+POST /endpoints/elevenlabs-webhook
+```
+
+## Authentication
+
+The webhook uses header-based authentication:
+- **Header**: `auth`
+- **Value**: Must match the `ELEVENLABS_WEBHOOK_AUTH` environment variable
+
+## Request Format
+
+The webhook receives the following payload from 11Labs:
+
+```json
+{
+  "caller_id": "+19093586520",
+  "agent_id": "agent_6201kbkk9f2de3ma3ntvjg7xdxs9",
+  "called_number": "+498941434322",
+  "call_sid": "CAb6906d9b35edb6666562caea0fb1d1aa",
+  "conversation_id": "conv_3701kesxp7rzfs5v51w069egjdvf"
+}
+```
+
+## Response Format
+
+The webhook returns dynamic variables that 11Labs can use in the conversation:
+
+```json
+{
+  "dynamic_variables": {
+    "host_name": "Test Hotel Group",
+    "test_account": "false",
+    "mode": "single-location",
+    "hotel_category": "luxury",
+    "preferred_currency": "EUR",
+    "welcomeMessage": "Welcome to our hotel",
+    "agent_name": "Assistant",
+    "formOfAddress": "Formal",
+    "formatted_user_number": "+1 - 909 - 358 - 6520",
+    "last_two_digits": "20",
+    "can_phone_number_receive_sms_details": "User phone number CAN receive SMS",
+    "location_details": "[{\"location_id\":\"loc1\",\"location_name\":\"Main Hotel\"}]"
+  }
+}
+```
+
+## Configuration
+
+### Environment Variables
+
+Add these to your `.env` file:
+
+```env
+# Required for webhook authentication
+ELEVENLABS_WEBHOOK_AUTH=your-secure-auth-token
+
+# Required for Supabase data fetching
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-supabase-anon-key
+```
+
+### 11Labs Agent Configuration
+
+In your 11Labs agent settings:
+1. Enable "Fetch initiation client data from a webhook"
+2. Set the webhook URL to: `https://your-api-domain/endpoints/elevenlabs-webhook`
+3. Configure the auth header with your secure token
+
+## Features
+
+### Number Blacklisting
+The webhook automatically blocks known scammer numbers:
+- `+41793000161`
+- `+491787169629`
+
+### Phone Number Formatting
+Phone numbers are automatically formatted for better readability:
+- US/Canada: `+1 - 909 - 358 - 6520`
+- Germany: `+49 - 123 - 456 - 789 - 0`
+
+### SMS Capability Detection
+The webhook detects if a phone number can receive SMS:
+- German mobile numbers (15x, 16x, 17x prefixes) are marked as SMS-capable
+- German landline numbers are marked as not SMS-capable
+- Other numbers are assumed to be SMS-capable
+
+### Multi-location Support
+The webhook detects if the account has single or multiple locations and sets the mode accordingly.
+
+## Supabase Schema
+
+The webhook expects the following Supabase structure:
+
+```sql
+-- Main table for location data
+onboarding_data
+  - id
+  - location_name
+  - check_in_support_type
+  - website_url
+  - contact_email
+
+-- Related phone number configuration
+phone_number
+  - id
+  - phone_number
+  - agent_config (JSONB)
+    - welcomeMessage
+    - agentName
+    - formOfAddress
+
+-- Account information
+aura_account
+  - name
+  - test_account
+  - hotel_category
+  - preferred_currency
+```
+
+## Testing
+
+Run the test suite:
+
+```bash
+uv run pytest tests/test_endpoints/test_elevenlabs_webhook.py -v
+```
+
+## Deployment
+
+### Local Development
+1. Copy `.env.example` to `.env`
+2. Fill in your configuration values
+3. Run the API: `uv run uvicorn gen_ai_on_aws.main:app --reload`
+
+### AWS Lambda
+The webhook is designed to work in AWS Lambda with secrets stored in AWS Secrets Manager. Configure the secret names in environment variables:
+- `ELEVENLABS_WEBHOOK_AUTH_SECRET_NAME`
+- `SUPABASE_URL_SECRET_NAME`
+- `SUPABASE_KEY_SECRET_NAME`
+
+## Error Handling
+
+The webhook handles errors gracefully:
+- **403 Forbidden**: Invalid or missing auth header
+- **200 with error**: Configuration not found or processing errors
+- All errors are logged for debugging
+
+## Example cURL Request
+
+```bash
+curl -X POST https://your-api-domain/endpoints/elevenlabs-webhook \
+  -H "Content-Type: application/json" \
+  -H "auth: your-secure-auth-token" \
+  -d '{
+    "caller_id": "+19093586520",
+    "agent_id": "agent_123",
+    "called_number": "+498941434322",
+    "call_sid": "CA123",
+    "conversation_id": "conv_456"
+  }'
+```

--- a/api/gen_ai_on_aws/auth.py
+++ b/api/gen_ai_on_aws/auth.py
@@ -1,0 +1,95 @@
+"""Authentication utilities for API endpoints."""
+
+import os
+
+from fastapi import Header, HTTPException, status
+from loguru import logger
+
+
+async def verify_webhook_auth(auth: str | None = Header(None)) -> str:
+    """Verify webhook authentication header.
+
+    This is a reusable dependency that can be used with any webhook endpoint
+    that needs header-based authentication.
+
+    Args:
+        auth: The auth header value from the request
+
+    Returns:
+        The authenticated header value
+
+    Raises:
+        HTTPException: 401 Unauthorized if auth fails
+    """
+    expected_auth = os.environ.get("ELEVENLABS_WEBHOOK_AUTH")
+
+    if not expected_auth:
+        logger.error("ELEVENLABS_WEBHOOK_AUTH not configured in environment")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Webhook authentication not configured",
+        )
+
+    if not auth:
+        logger.warning("Missing auth header in webhook request")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing authentication header"
+        )
+
+    if auth != expected_auth:
+        logger.warning(f"Invalid auth header received: {auth[:10]}..." if len(auth) > 10 else auth)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+    return auth
+
+
+def create_auth_dependency(env_var_name: str, header_name: str = "auth"):
+    """Factory function to create custom auth dependencies.
+
+    This allows creating auth dependencies for different services
+    with different environment variables and header names.
+
+    Args:
+        env_var_name: Name of the environment variable containing the expected token
+        header_name: Name of the header to check (default: "auth")
+
+    Returns:
+        A FastAPI dependency function for authentication
+
+    Example:
+        ```python
+        # Create a custom auth dependency for another service
+        verify_custom_auth = create_auth_dependency("CUSTOM_SERVICE_AUTH", "x-api-key")
+
+        @router.post("/custom-webhook")
+        async def custom_webhook(
+            payload: dict,
+            auth: str = Depends(verify_custom_auth)
+        ):
+            ...
+        ```
+    """
+
+    async def verify_auth(header_value: str | None = Header(None, alias=header_name)) -> str:
+        expected_auth = os.environ.get(env_var_name)
+
+        if not expected_auth:
+            logger.error(f"{env_var_name} not configured in environment")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Authentication not configured",
+            )
+
+        if not header_value:
+            logger.warning(f"Missing {header_name} header in request")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing authentication header"
+            )
+
+        if header_value != expected_auth:
+            logger.warning(f"Invalid {header_name} header received")
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+        return header_value
+
+    return verify_auth

--- a/api/gen_ai_on_aws/config.py
+++ b/api/gen_ai_on_aws/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     langfuse_host: str = "https://us.cloud.langfuse.com"
     supabase_url: str | None = None
     supabase_key: str | None = None
+    elevenlabs_webhook_auth: str | None = None
 
     # AWS Secrets Manager secret names (for AWS deployment)
     anthropic_api_key_secret_name: str | None = None
@@ -45,6 +46,7 @@ class Settings(BaseSettings):
     langfuse_secret_key_secret_name: str | None = None
     supabase_url_secret_name: str | None = None
     supabase_key_secret_name: str | None = None
+    elevenlabs_webhook_auth_secret_name: str | None = None
 
     sqs_queue_url: str | None = None
 
@@ -193,3 +195,6 @@ else:
     if settings.supabase_url and settings.supabase_key:
         os.environ["SUPABASE_URL"] = settings.supabase_url
         os.environ["SUPABASE_KEY"] = settings.supabase_key
+
+    if settings.elevenlabs_webhook_auth:
+        os.environ["ELEVENLABS_WEBHOOK_AUTH"] = settings.elevenlabs_webhook_auth

--- a/api/gen_ai_on_aws/endpoints/endpoints.py
+++ b/api/gen_ai_on_aws/endpoints/endpoints.py
@@ -7,8 +7,11 @@ from langfuse.decorators import langfuse_context, observe
 from litellm import completion
 from loguru import logger
 
+from gen_ai_on_aws.auth import verify_webhook_auth
 from gen_ai_on_aws.config import VERSION, settings
 from gen_ai_on_aws.endpoints.types import (
+    ElevenLabsWebhookPayload,
+    ElevenLabsWebhookResponse,
     ExtractUserAsyncResponse,
     ExtractUserRequest,
     SupabaseReadRequest,
@@ -173,3 +176,209 @@ async def supabase_read(
         raise HTTPException(
             status_code=500, detail=f"Failed to read from Supabase: {str(e)}"
         ) from e
+
+
+@router.post("/elevenlabs-webhook")
+async def elevenlabs_webhook(
+    payload: ElevenLabsWebhookPayload,
+    supabase_config: tuple[str, str] = Depends(get_supabase_config),
+    auth: str = Depends(verify_webhook_auth),
+) -> ElevenLabsWebhookResponse:
+    """Handle 11Labs conversation initiation webhook.
+
+    This endpoint:
+    1. Validates the auth header (via dependency)
+    2. Checks blacklisted numbers
+    3. Fetches client configuration from Supabase
+    4. Returns dynamic variables for the conversation
+
+    Args:
+        payload: The webhook payload from 11Labs
+        supabase_config: Supabase URL and key from dependency
+        auth: The authenticated header value (validated by dependency)
+
+    Returns:
+        ElevenLabsWebhookResponse with dynamic variables
+
+    Raises:
+        HTTPException: For auth failures or missing data
+    """
+    logger.info(f"Processing 11Labs webhook for conversation {payload.conversation_id}")
+
+    # Check blacklisted numbers (scammers)
+    blacklisted_numbers = ["+41793000161", "+491787169629"]
+    if payload.caller_id in blacklisted_numbers:
+        logger.warning(f"Blocked blacklisted number: {payload.caller_id}")
+        return ElevenLabsWebhookResponse(dynamic_variables={"error": "Number blocked"})
+
+    # Fetch location data from Supabase
+    supabase_url, supabase_key = supabase_config
+
+    try:
+        # Query for location data with phone number and account info
+        url = f"{supabase_url}/rest/v1/onboarding_data"
+        # Complex join query to fetch all related data
+        select_query = (
+            "*,"
+            "phone_number!inner("
+            "*,aura_account!inner(*),"
+            "agent_version!left(*,agent!inner(*))"
+            "),"
+            "hotel_restaurants!left(*),"
+            "closure_periods!left(*)"
+        )
+        params = {
+            "select": select_query,
+            "phone_number.phone_number": f"eq.{payload.called_number}",
+        }
+        headers = {
+            "apikey": supabase_key,
+            "Authorization": f"Bearer {supabase_key}",
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, params=params, headers=headers)
+            response.raise_for_status()
+
+        locations_data = response.json()
+
+        if not locations_data:
+            logger.warning(f"No configuration found for number: {payload.called_number}")
+            return ElevenLabsWebhookResponse(
+                dynamic_variables={"error": "Could not find client configuration"}
+            )
+
+        # Process the data (simplified version of the n8n logic)
+        first_location = locations_data[0]
+        phone_number_config = first_location.get("phone_number", {})
+        account = phone_number_config.get("aura_account", {})
+        agent_config = phone_number_config.get("agent_config", {})
+
+        # Format phone number
+        formatted_phone_number = _format_phone_number(payload.caller_id)
+
+        # Determine if phone can receive SMS (simplified)
+        can_receive_sms = _can_receive_sms(payload.caller_id)
+
+        # Build dynamic variables (matching the n8n structure)
+        dynamic_variables = {
+            "host_name": account.get("name", ""),
+            "test_account": str(account.get("test_account", False)),
+            "mode": "single-location" if len(locations_data) == 1 else "multi-location",
+            "hotel_category": account.get("hotel_category", ""),
+            "preferred_currency": account.get("preferred_currency", "EUR"),
+            "welcomeMessage": agent_config.get("welcomeMessage", ""),
+            "agent_name": agent_config.get("agentName", ""),
+            "formOfAddress": agent_config.get("formOfAddress", "Formal"),
+            "formatted_user_number": formatted_phone_number,
+            "last_two_digits": formatted_phone_number[-2:]
+            if len(formatted_phone_number) >= 2
+            else "",
+            "can_phone_number_receive_sms_details": "User phone number CAN receive SMS"
+            if can_receive_sms
+            else "User phone number CANNOT receive SMS",
+            "location_details": _serialize_locations(locations_data),
+        }
+
+        logger.info(f"Successfully processed webhook for {account.get('name', 'Unknown')}")
+
+        return ElevenLabsWebhookResponse(dynamic_variables=dynamic_variables)
+
+    except httpx.HTTPStatusError as e:
+        logger.error(f"Supabase error: {e}")
+        return ElevenLabsWebhookResponse(
+            dynamic_variables={"error": "Failed to fetch configuration"}
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error processing webhook: {e}")
+        return ElevenLabsWebhookResponse(dynamic_variables={"error": "Internal processing error"})
+
+
+def _format_phone_number(phone_number: str) -> str:
+    """Format a phone number for display.
+
+    Args:
+        phone_number: The raw phone number
+
+    Returns:
+        Formatted phone number with separators
+    """
+    if not phone_number or phone_number == "Anonymous":
+        return "Anonymous"
+
+    # Remove any non-digit characters except +
+    cleaned = "".join(c for c in phone_number if c.isdigit() or c == "+")
+
+    if not cleaned:
+        return phone_number
+
+    # Handle US/Canada numbers (+1 followed by 10 digits)
+    if cleaned.startswith("+1") and len(cleaned) == 12:
+        return f"+1 - {cleaned[2:5]} - {cleaned[5:8]} - {cleaned[8:]}"
+
+    # Handle German numbers (+49)
+    if cleaned.startswith("+49"):
+        country_code = cleaned[:3]
+        remaining = cleaned[3:]
+        # Format remaining digits in groups of 3
+        groups = []
+        for i in range(0, len(remaining), 3):
+            groups.append(remaining[i : i + 3])
+        return f"{country_code} - " + " - ".join(groups)
+
+    # Default formatting for other numbers
+    return phone_number
+
+
+def _can_receive_sms(phone_number: str) -> bool:
+    """Determine if a phone number can receive SMS.
+
+    Args:
+        phone_number: The phone number to check
+
+    Returns:
+        True if the number can receive SMS, False otherwise
+    """
+    if not phone_number or phone_number == "Anonymous":
+        return False
+
+    # German mobile numbers check
+    if phone_number.startswith("+49"):
+        # German mobile numbers use 15x, 16x, 17x prefixes
+        after_country = phone_number[3:]
+        if (
+            len(after_country) >= 2
+            and after_country[0] == "1"
+            and after_country[1] in ("5", "6", "7")
+        ):
+            return True
+        return False
+
+    # Assume other numbers can receive SMS
+    return True
+
+
+def _serialize_locations(locations_data: list) -> str:
+    """Serialize location data for dynamic variables.
+
+    Args:
+        locations_data: List of location data from Supabase
+
+    Returns:
+        JSON string of location details
+    """
+    import json
+
+    # Remove sensitive data and format for AI agent
+    locations = []
+    for loc in locations_data:
+        location = {
+            "location_id": loc.get("id"),
+            "location_name": loc.get("location_name"),
+            "check_in_support_type": loc.get("check_in_support_type", "not_specified"),
+            "website_url": loc.get("website_url", "not_specified"),
+            "contact_email": loc.get("contact_email", "not_specified"),
+        }
+        locations.append(location)
+
+    return json.dumps(locations, separators=(",", ":"))

--- a/api/gen_ai_on_aws/endpoints/types.py
+++ b/api/gen_ai_on_aws/endpoints/types.py
@@ -27,3 +27,21 @@ class SupabaseReadRequest(BaseModel):
 
 class SupabaseReadResponse(BaseModel):
     data: list[Any] = Field(description="The data returned from Supabase")
+
+
+class ElevenLabsWebhookPayload(BaseModel):
+    """Request payload from 11Labs conversation initiation webhook."""
+
+    caller_id: str = Field(description="The phone number of the caller")
+    agent_id: str = Field(description="The ID of the 11Labs agent")
+    called_number: str = Field(description="The number that was called")
+    call_sid: str = Field(description="The unique call session ID")
+    conversation_id: str = Field(description="The unique conversation ID")
+
+
+class ElevenLabsWebhookResponse(BaseModel):
+    """Response for 11Labs conversation initiation webhook."""
+
+    dynamic_variables: dict[str, Any] = Field(
+        description="Dynamic variables to inject into the agent conversation"
+    )

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1,0 +1,79 @@
+"""Tests for authentication utilities."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from gen_ai_on_aws.auth import create_auth_dependency, verify_webhook_auth
+
+
+class TestVerifyWebhookAuth:
+    """Test cases for verify_webhook_auth function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_auth(self):
+        """Test successful authentication."""
+        with patch.dict(os.environ, {"ELEVENLABS_WEBHOOK_AUTH": "valid-token"}):
+            result = await verify_webhook_auth("valid-token")
+            assert result == "valid-token"
+
+    @pytest.mark.asyncio
+    async def test_missing_auth_header(self):
+        """Test missing auth header."""
+        with patch.dict(os.environ, {"ELEVENLABS_WEBHOOK_AUTH": "valid-token"}):
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_webhook_auth(None)
+            assert exc_info.value.status_code == 401
+            assert exc_info.value.detail == "Missing authentication header"
+
+    @pytest.mark.asyncio
+    async def test_invalid_auth_header(self):
+        """Test invalid auth header."""
+        with patch.dict(os.environ, {"ELEVENLABS_WEBHOOK_AUTH": "valid-token"}):
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_webhook_auth("invalid-token")
+            assert exc_info.value.status_code == 401
+            assert exc_info.value.detail == "Unauthorized"
+
+    @pytest.mark.asyncio
+    async def test_missing_env_var(self):
+        """Test when environment variable is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_webhook_auth("any-token")
+            assert exc_info.value.status_code == 500
+            assert exc_info.value.detail == "Webhook authentication not configured"
+
+
+class TestCreateAuthDependency:
+    """Test cases for create_auth_dependency factory."""
+
+    @pytest.mark.asyncio
+    async def test_custom_auth_dependency(self):
+        """Test creating a custom auth dependency."""
+        with patch.dict(os.environ, {"CUSTOM_AUTH": "custom-token"}):
+            verify_custom = create_auth_dependency("CUSTOM_AUTH", "x-api-key")
+            result = await verify_custom("custom-token")
+            assert result == "custom-token"
+
+    @pytest.mark.asyncio
+    async def test_custom_auth_invalid(self):
+        """Test custom auth dependency with invalid token."""
+        with patch.dict(os.environ, {"CUSTOM_AUTH": "custom-token"}):
+            verify_custom = create_auth_dependency("CUSTOM_AUTH", "x-api-key")
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_custom("wrong-token")
+            assert exc_info.value.status_code == 401
+            assert exc_info.value.detail == "Unauthorized"
+
+    @pytest.mark.asyncio
+    async def test_custom_auth_missing_env(self):
+        """Test custom auth dependency when env var is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            verify_custom = create_auth_dependency("CUSTOM_AUTH", "x-api-key")
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_custom("any-token")
+            assert exc_info.value.status_code == 500
+            assert exc_info.value.detail == "Authentication not configured"

--- a/api/tests/test_endpoints/test_elevenlabs_webhook.py
+++ b/api/tests/test_endpoints/test_elevenlabs_webhook.py
@@ -1,0 +1,200 @@
+"""Tests for the 11Labs webhook endpoint."""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gen_ai_on_aws.main import app
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def valid_webhook_payload():
+    """Create a valid webhook payload."""
+    return {
+        "caller_id": "+19093586520",
+        "agent_id": "agent_6201kbkk9f2de3ma3ntvjg7xdxs9",
+        "called_number": "+498941434322",
+        "call_sid": "CAb6906d9b35edb6666562caea0fb1d1aa",
+        "conversation_id": "conv_3701kesxp7rzfs5v51w069egjdvf",
+    }
+
+
+@pytest.fixture
+def mock_supabase_response():
+    """Mock Supabase response data."""
+    return [
+        {
+            "id": "location1",
+            "location_name": "Test Hotel",
+            "check_in_support_type": "24/7",
+            "website_url": "https://test-hotel.com",
+            "contact_email": "info@test-hotel.com",
+            "phone_number": {
+                "id": "phone1",
+                "phone_number": "+498941434322",
+                "aura_account": {
+                    "name": "Test Hotel Group",
+                    "test_account": False,
+                    "hotel_category": "luxury",
+                    "preferred_currency": "EUR",
+                },
+                "agent_config": {
+                    "welcomeMessage": "Welcome to Test Hotel",
+                    "agentName": "Assistant",
+                    "formOfAddress": "Formal",
+                },
+            },
+        }
+    ]
+
+
+class TestElevenLabsWebhook:
+    """Test cases for the 11Labs webhook endpoint."""
+
+    def test_missing_auth_header(self, client):
+        """Test that missing auth header returns 401."""
+        with patch.dict(os.environ, {"ELEVENLABS_WEBHOOK_AUTH": "test-auth-token"}):
+            response = client.post(
+                "/endpoints/elevenlabs-webhook",
+                json={
+                    "caller_id": "+19093586520",
+                    "agent_id": "test_agent",
+                    "called_number": "+498941434322",
+                    "call_sid": "test_sid",
+                    "conversation_id": "test_conversation",
+                },
+            )
+            assert response.status_code == 401
+
+    def test_invalid_auth_header(self, client):
+        """Test that invalid auth header returns 401."""
+        with patch.dict(os.environ, {"ELEVENLABS_WEBHOOK_AUTH": "test-auth-token"}):
+            response = client.post(
+                "/endpoints/elevenlabs-webhook",
+                json={
+                    "caller_id": "+19093586520",
+                    "agent_id": "test_agent",
+                    "called_number": "+498941434322",
+                    "call_sid": "test_sid",
+                    "conversation_id": "test_conversation",
+                },
+                headers={"auth": "wrong-token"},
+            )
+            assert response.status_code == 401
+
+    def test_blacklisted_number(self, client, valid_webhook_payload):
+        """Test that blacklisted numbers are blocked."""
+        with patch.dict(
+            os.environ,
+            {
+                "ELEVENLABS_WEBHOOK_AUTH": "test-auth-token",
+                "SUPABASE_URL": "https://test.supabase.co",
+                "SUPABASE_KEY": "test-key",
+            },
+        ):
+            # Use a blacklisted number
+            valid_webhook_payload["caller_id"] = "+41793000161"
+            response = client.post(
+                "/endpoints/elevenlabs-webhook",
+                json=valid_webhook_payload,
+                headers={"auth": "test-auth-token"},
+            )
+            assert response.status_code == 200
+            assert response.json()["dynamic_variables"]["error"] == "Number blocked"
+
+    @pytest.mark.asyncio
+    async def test_successful_webhook(self, client, valid_webhook_payload, mock_supabase_response):
+        """Test successful webhook processing."""
+        with patch.dict(
+            os.environ,
+            {
+                "ELEVENLABS_WEBHOOK_AUTH": "test-auth-token",
+                "SUPABASE_URL": "https://test.supabase.co",
+                "SUPABASE_KEY": "test-key",
+            },
+        ):
+            # Mock the httpx client
+            mock_response = AsyncMock()
+            mock_response.raise_for_status = AsyncMock()
+            mock_response.json = lambda: mock_supabase_response
+
+            with patch("httpx.AsyncClient.get", return_value=mock_response):
+                response = client.post(
+                    "/endpoints/elevenlabs-webhook",
+                    json=valid_webhook_payload,
+                    headers={"auth": "test-auth-token"},
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+                assert "dynamic_variables" in data
+                assert data["dynamic_variables"]["host_name"] == "Test Hotel Group"
+                assert data["dynamic_variables"]["mode"] == "single-location"
+                assert data["dynamic_variables"]["formatted_user_number"] == "+1 - 909 - 358 - 6520"
+
+    @pytest.mark.asyncio
+    async def test_no_data_found(self, client, valid_webhook_payload):
+        """Test when no configuration is found in Supabase."""
+        with patch.dict(
+            os.environ,
+            {
+                "ELEVENLABS_WEBHOOK_AUTH": "test-auth-token",
+                "SUPABASE_URL": "https://test.supabase.co",
+                "SUPABASE_KEY": "test-key",
+            },
+        ):
+            # Mock empty response from Supabase
+            mock_response = AsyncMock()
+            mock_response.raise_for_status = AsyncMock()
+            mock_response.json = lambda: []
+
+            with patch("httpx.AsyncClient.get", return_value=mock_response):
+                response = client.post(
+                    "/endpoints/elevenlabs-webhook",
+                    json=valid_webhook_payload,
+                    headers={"auth": "test-auth-token"},
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+                assert data["dynamic_variables"]["error"] == "Could not find client configuration"
+
+    def test_phone_number_formatting(self):
+        """Test phone number formatting function."""
+        from gen_ai_on_aws.endpoints.endpoints import _format_phone_number
+
+        # Test US number
+        assert _format_phone_number("+19093586520") == "+1 - 909 - 358 - 6520"
+
+        # Test German number
+        assert _format_phone_number("+491234567890") == "+49 - 123 - 456 - 789 - 0"
+
+        # Test anonymous
+        assert _format_phone_number("Anonymous") == "Anonymous"
+
+        # Test empty
+        assert _format_phone_number("") == "Anonymous"
+
+    def test_sms_capability(self):
+        """Test SMS capability detection."""
+        from gen_ai_on_aws.endpoints.endpoints import _can_receive_sms
+
+        # Test German mobile number
+        assert _can_receive_sms("+491701234567") is True
+
+        # Test German landline
+        assert _can_receive_sms("+493012345678") is False
+
+        # Test US number (assumed capable)
+        assert _can_receive_sms("+19093586520") is True
+
+        # Test anonymous
+        assert _can_receive_sms("Anonymous") is False


### PR DESCRIPTION
- Add reusable authentication utilities in auth.py
  - verify_webhook_auth for 11Labs webhook header-based auth
  - create_auth_dependency factory for creating custom auth dependencies

- Implement /elevenlabs-webhook endpoint
  - Validates auth header using dependency injection
  - Checks blacklisted phone numbers
  - Fetches location configuration from Supabase
  - Returns dynamic variables for conversation personalization

- Add helper functions
  - Phone number formatting for US/Canada and German numbers
  - SMS capability detection based on phone number patterns
  - Location data serialization for dynamic variables

- Add comprehensive test coverage
  - Unit tests for authentication utilities
  - Integration tests for webhook endpoint
  - Tests for phone formatting and SMS detection

- Add documentation and configuration
  - Detailed webhook integration documentation
  - .env.example with all required environment variables
  - Support for AWS Secrets Manager in Lambda deployment